### PR TITLE
Update protection.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Mage - Fire
 
 Druid - Feral
 
+Demon Hunter - Vengeance
+
 ------------------------------------
 
 Future routines + WIP (do not use them even if you see them on github):
@@ -43,8 +45,6 @@ Death Knight - Frost
 Death Knight - Unholy
 
 Demon Hunter - Havoc
-
-Demon Hunter - Vengeance
 
 Druid - Balance
 

--- a/conditions.lua
+++ b/conditions.lua
@@ -51,7 +51,7 @@ local PowerT = {
 	[3] = ('^.-Energy'),
 }
 
---/dump NeP.DSL.Conditions['action.cost']('Maim')
+
 --/dump NeP.DSL.Conditions['action.cost']('Rake')
 --/dump NeP.DSL.Conditions['action.cost']('Rejuvenation')
 NeP.DSL.RegisterConditon('action.cost', function(spell)
@@ -68,6 +68,26 @@ NeP.DSL.RegisterConditon('action.cost', function(spell)
 		else
 			return 0
 		end
+end)
+
+
+--UnitBuff(Unit,GetSpellInfo(SpellID))
+--/dump GetSpellInfo(190456)
+--/dump UnitBuff('player',GetSpellInfo(190456))
+
+--/dump NeP.DSL.Conditions['ignorepain_cost']()
+NeP.DSL.RegisterConditon('ignorepain_cost', function()
+	return Xeer:Scan_IgnorePain()
+end)
+
+--/dump NeP.DSL.Conditions['ignorepain_max']()
+NeP.DSL.RegisterConditon('ignorepain_max', function()
+	local ss = NeP.DSL.Conditions['health.max']('player')
+	if hasTalent(5,2) == true then
+		return NeP.Core.Round((((77.86412474516502 * 1.70) * ss) / 100))
+	else
+		return NeP.Core.Round(((77.86412474516502 * ss) / 100))
+	end
 end)
 
 --------------------------------------FERAL-------------------------------------
@@ -144,7 +164,9 @@ end)
 --/dump NeP.DSL.Conditions['cast_time']('player','Cinderstorm')
 
 
---/dump NeP.DSL.Conditions['buff']('player','202060')
+--/dump NeP.DSL.Conditions['ignorepain_max']('player')
+
+
 
 NeP.DSL.RegisterConditon('buff.react', function(target, spell)
 	local x = NeP.DSL.Conditions['buff.count'](target, spell)
@@ -207,6 +229,7 @@ NeP.DSL.RegisterConditon('time', function(target)
 	return NeP.DSL.Conditions['combat.time'](target)
 end)
 
+--/dump NeP.DSL.Conditions['spell.cooldown']('player','Rip')
 NeP.DSL.RegisterConditon('cooldown.remains', function(_, spell)
 	if NeP.DSL.Conditions['spell.exists'](_, spell) == true then
 		return NeP.DSL.Conditions['spell.cooldown'](_, spell)

--- a/rotations/demonhunter/vengeance.lua
+++ b/rotations/demonhunter/vengeance.lua
@@ -1,75 +1,125 @@
 local GUI = {
-
 }
 
 local exeOnLoad = function()
-	--Xeer.Splash()
+	Xeer.Splash()
+
+	print('|cffADFF2F ----------------------------------------------------------------------|r')
+	print('|cffADFF2F --- |rDEMON HUNTER |cffADFF2FVengeance |r')
+	print('|cffADFF2F --- |rRecommended Talents: 1/3 - 2/3 - 3/2 - 4/3 - 5/3 - 6/1 - 7/3')
+	print('|cffADFF2F ----------------------------------------------------------------------|r')
+
 end
+
+local _Xeer = {
+	-- some non-SiMC stuffs
+	{'@Xeer.Targeting()', {'!target.alive', 'toggle(AutoTarget)'}},
+
+--[[
+demonhunter='Demon_Hunter_Vengeance_T19P'
+level=110
+race=night_elf
+timeofday=night
+role=tank
+position=front
+talents=3323313
+artifact=60:0:0:0:0:1096:1:1098:1:1099:1:1228:1:1229:3:1230:3:1231:3:1234:3:1236:1:1328:1:1434:1
+spec=vengeance
+
+# Gear Summary
+# gear_ilvl=826.25
+# gear_agility=8531
+# gear_stamina=14978
+# gear_crit_rating=9245
+# gear_haste_rating=834
+# gear_mastery_rating=1733
+# gear_versatility_rating=4695
+# gear_armor=1830
+--]]
+}
 
 local Keybinds = {
 	{'%pause', 'keybind(alt)'},
 	{'Sigil of Flame', 'keybind(lshift)', 'mouseover.ground'},
-	{'Metamorphosis', 'keybind(lcontrol)', 'mouseover.ground'}
+	--{'Metamorphosis', 'keybind(lcontrol)', 'mouseover.ground'},
+	{'Infernal Strike', 'keybind(lcontrol)', 'mouseover.ground'}
 }
 
 local Interrupts = {
+	{'Arcane Torrent', 'target.range<=8&spell(Consume Magic).cooldown>1&!prev_gcd(Consume Magic)'},
 	{'Consume Magic'},
 }
 
 local ST = {
 	--actions+=/fiery_brand,if=buff.demon_spikes.down&buff.metamorphosis.down
-	{'Fiery Brand', {'!player.buff(Demon Spikes)', '!player.buff(Metamorphosis)'}},
+	{'Fiery Brand', '!buff(Demon Spikes)&!buff(Metamorphosis)'},
 	--actions+=/demon_spikes,if=charges=2|buff.demon_spikes.down&!dot.fiery_brand.ticking&buff.metamorphosis.down
-	{'Demon Spikes', {'spell.charges=2', 'or', 'player.buff(Demon Spikes)', '!target.debuff(Fiery Brand)', '!player.buff(Metamorphosis)'}},
+	{'Demon Spikes', '{spell(Demon Spikes)charges=2||!buff(Demon Spikes)}&!target.debuff(Fiery Brand)&!buff(Metamorphosis)'},
 	--actions+=/empower_wards,if=debuff.casting.up
-	{'Empower Wards', 'target.debuff(Casting)'},
+	{'!Empower Wards', 'target.casting.percent>80'},
 	--actions+=/infernal_strike,if=!sigil_placed&!in_flight&remains-travel_time-delay<0.3*duration&artifact.fiery_demise.enabled&dot.fiery_brand.ticking
 	--actions+=/infernal_strike,if=!sigil_placed&!in_flight&remains-travel_time-delay<0.3*duration&(!artifact.fiery_demise.enabled|(max_charges-charges_fractional)*recharge_time<cooldown.fiery_brand.remains+5)&(cooldown.sigil_of_flame.remains>7|charges=2)
+	{'Sigil of Flame', '!target.debuff(Sigil of Flame)', 'target.ground'},
 	--actions+=/spirit_bomb,if=debuff.frailty.down
-	{'Spirit Bomb', '!target.debuff(Frailty)'},
+	{'Spirit Bomb', '!prev_gcd(Spirit Bomb)&!target.debuff(Frailty)&buff(Soul Fragments).count>=1'},
 	--actions+=/soul_carver,if=dot.fiery_brand.ticking
 	{'Soul Carver', 'target.debuff(Fiery Brand)'},
 	--actions+=/immolation_aura,if=pain<=80
-	{'Immolation Aura', 'player.pain<=80'},
+	{'Immolation Aura', 'pain<=80'},
 	--actions+=/felblade,if=pain<=70
-	{'Felblade', 'player.pain<=70'},
+	{'Felblade', 'talent(3,1)&pain<=70'},
 	--actions+=/soul_barrier
-	{'Soul Barrier'},
+	{'Soul Barrier', 'talent(7,3)'},
 	--actions+=/soul_cleave,if=soul_fragments=5
-	{'Soul Cleave', 'player.buff(Soul Fragments).count=5'},
-	{{
-		--actions+=/metamorphosis,if=buff.demon_spikes.down&!dot.fiery_brand.ticking&buff.metamorphosis.down&incoming_damage_5s>health.max*0.70
-		{'Metamorphosis', {'advancedGround','!player.buff(Demon Spikes)','!target.debuff(Fiery Brand)','!player.buff'}, 'target.ground'},
-		--actions+=/fel_devastation,if=incoming_damage_5s>health.max*0.70
-		{'Fel Devastation'},
-		--actions+=/soul_cleave,if=incoming_damage_5s>=health.max*0.70
-		{'Soul Cleave'}
-	}, 'player.incdmg(5)>=health.max*0.70'},
+	{'Soul Cleave', 'buff(Soul Fragments).count=5'},
+	--actions+=/metamorphosis,if=buff.demon_spikes.down&!dot.fiery_brand.ticking&buff.metamorphosis.down&incoming_damage_5s>health.max*0.70
+	{'Metamorphosis', '!buff(Demon Spikes)&!target.dot(Fiery Brand).ticking&!buff(Metamorphosis)&incdmg(5)>=health.max*0.70'},
+	--actions+=/fel_devastation,if=incoming_damage_5s>health.max*0.70
+	{'Fel Devastation', 'talent(6,1)&incdmg(5)>=health.max*0.70'},
+	--actions+=/soul_cleave,if=incoming_damage_5s>=health.max*0.70
+	{'Soul Cleave', 'incdmg(5)>=health.max*0.70'},
 	--actions+=/fel_eruption
-	{'Fel Eruption'},
+	{'Fel Eruption', 'talent(3,3)'},
 	--actions+=/sigil_of_flame,if=remains-delay<=0.3*duration
 	--{'Sigil of Flame', {'advancedGround', 'totem.duration<=0.3*totem.time'}, 'target.ground'},
 	--actions+=/fracture,if=pain>=80&soul_fragments<4&incoming_damage_4s<=health.max*0.20
-	{'Soul Cleave', {'player.pain>=80', 'player.buff(Soul Fragments).count<4', 'player.incdmg(4)<=player.maxhealth*0.20'}},
+	{'Soul Cleave', 'pain>=80&buff(Soul Fragments).count<4&incdmg(4)<=health.max*0.20'},
 	--actions+=/soul_cleave,if=pain>=80
-	{'Soul Cleave', 'player.pain>=80'},
+	{'Soul Cleave', 'pain>=80'},
+	{'Shear', 'buff(Blade Turning)'},
+	{'Fracture', 'talent(4,2)&pain>=60'},
 	--actions+=/shear
 	{'Shear'}
+}
+
+local xCombat = {
+	{'Soul Carver'},
+	{'Fel Devastation', 'talent(6,1)&incdmg(5)>=health.max*0.70'},
+	{'Soul Cleave', 'pain>=80'},
+	{'Immolation Aura', 'pain<=80'},
+	{'Felblade', 'talent(3,1)&pain<=80'},
+	{'Fel Eruption', 'talent(3,3)'},
+	{'Spirit Bomb', '!prev_gcd(Spirit Bomb)&!target.debuff(Frailty)&buff(Soul Fragments).count>=1'},
+	{'Shear', 'buff(Blade Turning)'},
+	{'Fracture', 'talent(4,2)&pain>=60'},
+	{'Sigil of Flame', 'target.ground'},
+	--actions+=/shear
+	{'Shear'}
+}
+
+local Ranged = {
+	{'Throw Glaive'},
 }
 
 local inCombat = {
 	{Keybinds},
 	{Interrupts, 'target.interruptAt(40)'},
-	{ST, 'target.infront'}
+	{Ranged, 'target.range>8&target.range<=30'},
+	{ST, 'target.infront&target.range<=8'}
 }
 
 local outCombat = {
-	--actions.precombat=flask,type=flask_of_the_seventh_demon
-	--actions.precombat+=/food,type=the_hungry_magister
-	--actions.precombat+=/augmentation,type=defiled
-	--# Snapshot raid buffed stats before combat begins and pre-potting is done.
-	--actions.precombat+=/snapshot_stats
-	--actions.precombat+=/potion,name=unbending_potion
+	{Keybinds},
 }
 
-NeP.Engine.registerRotation(581, '[|cff'..Xeer.Interface.addonColor..'Xeer|r] Demon Hunter - Vengeance', inCombat, outCombat, exeOnLoad, GUI)
+NeP.Engine.registerRotation(581, '[|cff'..Xeer.Interface.addonColor..'Xeer|r] DEMON HUNTER - Vengeance', inCombat, outCombat, exeOnLoad, GUI)

--- a/rotations/mage/fire.lua
+++ b/rotations/mage/fire.lua
@@ -109,7 +109,7 @@ local Combustion = {
 	--actions.combustion_phase+=/pyroblast,if=buff.hot_streak.up
 	{'Pyroblast', 'buff(Hot Streak!)'},
 	--actions.combustion_phase+=/fire_blast,if=buff.heating_up.up
-	{'!Fire Blast', 'action(Fire Blast).charges>=1&buff(Heating Up)'},
+	{'&Fire Blast', 'action(Fire Blast).charges>=1&buff(Heating Up)'},
 	--actions.combustion_phase+=/phoenixs_flames
 	{'Phoenix\'s Flames', 'artifact(Phoenix\'s Flames).equipped'},
 	--actions.combustion_phase+=/scorch,if=buff.combustion.remains>cast_time
@@ -128,7 +128,7 @@ local RoP = {
 	--actions.rop_phase+=/pyroblast,if=buff.kaelthas_ultimate_ability.react
 	{'Pyroblast', 'buff(Kael\'thas\'s Ultimate Ability).react'},
 	--actions.rop_phase+=/fire_blast,if=!prev_off_gcd.fire_blast
-	{'Fire Blast', 'action(Fire Blast).charges>=1&!prev_off_gcd(Fire Blast)'},
+	{'&Fire Blast', 'action(Fire Blast).charges>=1&!prev_off_gcd(Fire Blast)'},
 	--actions.rop_phase+=/phoenixs_flames,if=!prev_gcd.phoenixs_flames
 	{'Phoenix\'s Flames', 'artifact(Phoenix\'s Flames).equipped&!prev_gcd(Phoenix\'s Flames)'},
 	--actions.rop_phase+=/scorch,if=target.health.pct<=25&equipped.132454
@@ -153,9 +153,9 @@ local MainRotation = {
 	--actions.single_target+=/call_action_list,name=active_talents
 	{Talents},
 	--actions.single_target+=/fire_blast,if=!talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled||charges_fractional>1.4||cooldown.combustion.remains<40)&(3-charges_fractional)*(12*spell_haste)<cooldown.combustion.remains+3||target.time_to_die.remains<4
-	{'!Fire Blast', '!talent(7,1)&buff(Heating Up)&{!talent(3,2)||action(Fire Blast).charges>1.4||cooldown(Combustion).remains<40}&{3-action(Fire Blast).charges}*{12*spell_haste}<=cooldown(Combustion).remains||target.time_to_die.remains<4'},
+	{'&Fire Blast', '!talent(7,1)&buff(Heating Up)&{!talent(3,2)||action(Fire Blast).charges>1.4||cooldown(Combustion).remains<40}&{3-action(Fire Blast).charges}*{12*spell_haste}<=cooldown(Combustion).remains||target.time_to_die.remains<4'},
 	--actions.single_target+=/fire_blast,if=talent.kindling.enabled&buff.heating_up.up&(!talent.rune_of_power.enabled||charges_fractional>1.5||cooldown.combustion.remains<40)&(3-charges_fractional)*(18*spell_haste)<cooldown.combustion.remains+3||target.time_to_die.remains<4
-	{'!Fire Blast', 'talent(7,1)&buff(Heating Up)&{!talent(3,2)||action(Fire Blast).charges>1.5||{cooldown(Combustion).remains<40}}&{3-action(Fire Blast).charges}*{18*spell_haste}<=cooldown(Combustion).remains||target.time_to_die.remains<4'},
+	{'&Fire Blast', 'talent(7,1)&buff(Heating Up)&{!talent(3,2)||action(Fire Blast).charges>1.5||{cooldown(Combustion).remains<40}}&{3-action(Fire Blast).charges}*{18*spell_haste}<=cooldown(Combustion).remains||target.time_to_die.remains<4'},
 	--actions.single_target+=/phoenixs_flames,if=(buff.combustion.up||buff.rune_of_power.up||buff.incanters_flow.stack>3||talent.mirror_image.enabled)&artifact.phoenix_reborn.enabled&(4-charges_fractional)*13<cooldown.combustion.remains+5||target.time_to_die.remains<10
 	{'Phoenix\'s Flames', '{buff(Combustion)||buff(Rune of Power)||buff(Incanter\'s Flow).stack>3||talent(3,1)}&{4-action(Phoenix\'s Flames).charges} * 13<cooldown(Combustion).remains + 5||target.time_to_die.remains<10'},
 	--actions.single_target+=/phoenixs_flames,if=(buff.combustion.up||buff.rune_of_power.up)&(4-charges_fractional)*30<cooldown.combustion.remains+5
@@ -170,7 +170,7 @@ local xCombat = {
 	--actions+=/call_action_list,name=combustion_phase,if=cooldown.combustion.remains<=action.rune_of_power.cast_time+(!talent.kindling.enabled*gcd)||buff.combustion.up
 	{Combustion, 'cooldown(Combustion).remains<=action(Rune of Power).cast_time||buff(Combustion)'},
 	--actions+=/call_action_list,name=rop_phase,if=buff.rune_of_power.up&buff.combustion.down
-	{RoP, 'buff(Rune of Power)&!buff(Combustion)'},
+	{RoP, 'buff(Rune of Power)&!buff(Combustion)&xmoving=0'},
 	--actions+=/call_action_list,name=single_target
 	{MainRotation}
 }

--- a/rotations/warrior/protection.lua
+++ b/rotations/warrior/protection.lua
@@ -127,7 +127,7 @@ local ST = {
 	{AoE, 'area(8).enemies>=2'},
 	{Something},
 	--actions.prot+=/neltharions_fury,if=incoming_damage_2500ms>health.max*0.20&!buff.shield_block.up
-	{'Neltharion\'s Fury', 'incdmg(2.5)>health.max*0.20&target.infront&!buff(Shield Block)'},
+	{'Neltharion\'s Fury', 'incdmg(2.5)>health.max*0.20&!buff(Shield Block)'},
 	--actions.prot+=/shield_slam,if=!(cooldown.shield_block.remains<=gcd.max*2&!buff.shield_block.up&talent.heavy_repercussions.enabled)
 	{'Shield Slam', '!{spell(Shield Block).cooldown<=gcd&!buff(Shield Block)&talent(7,2)}||{buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage<13}||{!buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage<20}||'},
 	{'Shield Slam', '!talent(7,2)'},

--- a/rotations/warrior/protection.lua
+++ b/rotations/warrior/protection.lua
@@ -54,7 +54,9 @@ local Keybinds = {
 }
 
 local Interrupts = {
-	{'Pummel'}
+	{'Pummel'},
+	{'Arcane Torrent', 'target.range<=8&spell(Pummel).cooldown>1&!prev_gcd(Pummel)'},
+	{'Shockwave', 'talent(1,1)&target.infront&!target.immune(stun)'}
 }
 
 local Cooldowns = {
@@ -81,13 +83,13 @@ local Something = {
 	--same skills in same order in both parts of rotation... placed them here :)
 	--actions.prot_aoe=focused_rage,if=talent.ultimatum.enabled&buff.ultimatum.up&!talent.vengeance.enabled
 	--actions.prot+=/focused_rage,if=talent.ultimatum.enabled&buff.ultimatum.up&!talent.vengeance.enabled
-	{'Focused Rage', 'talent(3,2)&buff(Ultimatum)&!talent(6,1)'},
+	--{'Focused Rage', 'talent(3,2)&buff(Ultimatum)&!talent(6,1)'},
 	--actions.prot_aoe+=/battle_cry,if=(talent.vengeance.enabled&talent.ultimatum.enabled&cooldown.shield_slam.remains<=5-gcd.max-0.5)||!talent.vengeance.enabled
 	--actions.prot+=/battle_cry,if=(talent.vengeance.enabled&talent.ultimatum.enabled&cooldown.shield_slam.remains<=5-gcd.max-0.5)||!talent.vengeance.enabled
 	{'Battle Cry', '{talent(6,1)&talent(3,2)&spell(Shield Slam).cooldown<=4.5-gcd}||!talent(6,1)'},
 	--actions.prot_aoe+=/demoralizing_shout,if=talent.booming_voice.enabled&buff.battle_cry.up
 	--actions.prot+=/demoralizing_shout,if=talent.booming_voice.enabled&buff.battle_cry.up
-	{'Demoralizing Shout', 'talent(6,3)&buff(Battle Cry)'},
+	{'Demoralizing Shout', 'talent(6,3)&buff(Battle Cry)||area(6).enemies>=3'}
 	--actions.prot_aoe+=/ravager,if=talent.ravager.enabled&buff.battle_cry.up
 	--actions.prot+=/ravager,if=talent.ravager.enabled&buff.battle_cry.up
 	{'Ravager', 'talent(7,3)&buff(Battle Cry)'}
@@ -96,7 +98,7 @@ local Something = {
 local AoE = {
 	{Something},
 	--actions.prot_aoe+=/neltharions_fury,if=buff.battle_cry.up
-	{'Neltharion\'s Fury', 'buff(Battle Cry)'},
+	{'Neltharion\'s Fury', 'target.infront&buff(Battle Cry)'},
 	--actions.prot_aoe+=/shield_slam,if=!(cooldown.shield_block.remains<=gcd.max*2&!buff.shield_block.up&talent.heavy_repercussions.enabled)
 	{'Shield Slam', '!{spell(Shield Block).cooldown<=gcd*2&!buff(Shield Block)&talent(7,2)}'},
 	--actions.prot_aoe+=/revenge
@@ -113,24 +115,24 @@ local ST = {
 	--actions.prot+=/ignore_pain,if=(rage>=60&!talent.vengeance.enabled)||(buff.vengeance_ignore_pain.up&buff.ultimatum.up)||(buff.vengeance_ignore_pain.up&rage>=30)||(talent.vengeance.enabled&!buff.ultimatum.up&!buff.vengeance_ignore_pain.up&!buff.vengeance_focused_rage.up&rage<30)
 	{'!Ignore Pain','{buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage>=13}||{!buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage>=20}||{rage>=60&!talent(6,1)}||{buff(Vengeance: Ignore Pain)&buff(Ultimatum)}||{buff(Vengeance: Ignore Pain)&rage>=30}||{talent(6,1)&!buff(Ultimatum)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)&rage<30}'},
 	--actions.prot+=/focused_rage,if=(buff.vengeance_focused_rage.up&!buff.vengeance_ignore_pain.up)||(buff.ultimatum.up&buff.vengeance_focused_rage.up&!buff.vengeance_ignore_pain.up)||(talent.vengeance.enabled&buff.ultimatum.up&!buff.vengeance_ignore_pain.up&!buff.vengeance_focused_rage.up)||(talent.vengeance.enabled&!buff.vengeance_ignore_pain.up&!buff.vengeance_focused_rage.up&rage>=30)||(buff.ultimatum.up&buff.vengeance_ignore_pain.up&cooldown.shield_slam.remains=0&rage<10)||(rage>=100)
-	{'Focused Rage', '{buff(Vengeance: Focused Rage)&!buff(Vengeance: Ignore Pain)}||{buff(Ultimatum)&buff(Vengeance: Focused Rage)&!buff(Vengeance: Ignore Pain)}||{talent(6,1)&buff(Ultimatum)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)}||{talent(6,1)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)&rage>=30}||{buff(Ultimatum)&buff(Vengeance: Ignore Pain)&spell(Shield Slam)&rage<10}||{rage>=100}'},
+	--{'Focused Rage', '{buff(Vengeance: Focused Rage)&!buff(Vengeance: Ignore Pain)}||{buff(Ultimatum)&buff(Vengeance: Focused Rage)&!buff(Vengeance: Ignore Pain)}||{talent(6,1)&buff(Ultimatum)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)}||{talent(6,1)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)&rage>=30}||{buff(Ultimatum)&buff(Vengeance: Ignore Pain)&spell(Shield Slam)&rage<10}||{rage>=100}'},
 	--actions.prot+=/demoralizing_shout,if=incoming_damage_2500ms>health.max*0.20
 	{'Demoralizing Shout', 'incdmg(2.5)>health.max*0.20'},
 	--actions.prot+=/shield_wall,if=incoming_damage_2500ms>health.max*0.50
 	{'Shield Wall', 'incdmg(2.5)>health.max*0.50'},
 	--actions.prot+=/last_stand,if=incoming_damage_2500ms>health.max*0.50&!cooldown.shield_wall.remains=0
-	{'Last Stand', 'incdmg(2.5)>health.max*0.50&!spell(Shield Wall).cooldown=0'},
+	{'Last Stand', 'incdmg(2.5)>player.health'},
 	--actions.prot+=/potion,name=unbending_potion,if=(incoming_damage_2500ms>health.max*0.15&!buff.potion.up)||target.time_to_die<=25
 	--actions.prot+=/call_action_list,name=prot_aoe,if=spell_targets.neltharions_fury>=2
 	{AoE, 'area(8).enemies>=2'},
 	{Something},
 	--actions.prot+=/neltharions_fury,if=incoming_damage_2500ms>health.max*0.20&!buff.shield_block.up
-	{'Neltharion\'s Fury', 'incdmg(2.5)>health.max*0.20&!buff(Shield Block)'},
+	{'Neltharion\'s Fury', 'incdmg(2.5)>health.max*0.20&target.infront&!buff(Shield Block)'},
 	--actions.prot+=/shield_slam,if=!(cooldown.shield_block.remains<=gcd.max*2&!buff.shield_block.up&talent.heavy_repercussions.enabled)
 	{'Shield Slam', '!{spell(Shield Block).cooldown<=gcd&!buff(Shield Block)&talent(7,2)}||{buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage<13}||{!buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage<20}||'},
 	{'Shield Slam', '!talent(7,2)'},
 	--actions.prot+=/revenge,if=cooldown.shield_slam.remains<=gcd.max*2
-	{'Revenge', '{spell(Shield Slam).cooldown<=gcd*2||rage<=5}'},
+	{'Revenge', '{spell(Shield Slam).cooldown<=gcd*2'},
 	--actions.prot+=/devastate
 	{'Devastate'}
 }

--- a/rotations/warrior/protection.lua
+++ b/rotations/warrior/protection.lua
@@ -111,7 +111,7 @@ local ST = {
 	--actions.prot=shield_block,if=!buff.neltharions_fury.up&((cooldown.shield_slam.remains<6&!buff.shield_block.up)||(cooldown.shield_slam.remains<6+buff.shield_block.remains&buff.shield_block.up))
 	{'Shield Block', '!buff(Neltharion\'s Fury)&{{spell(Shield Slam).cooldown<6&!buff(Shield Block)}||{spell(Shield Slam).cooldown<6+buff(Shield Block).duration&buff(Shield Block)}}'},
 	--actions.prot+=/ignore_pain,if=(rage>=60&!talent.vengeance.enabled)||(buff.vengeance_ignore_pain.up&buff.ultimatum.up)||(buff.vengeance_ignore_pain.up&rage>=30)||(talent.vengeance.enabled&!buff.ultimatum.up&!buff.vengeance_ignore_pain.up&!buff.vengeance_focused_rage.up&rage<30)
-	{'Ignore Pain','{rage>=60&!talent(6,1)}||{buff(Vengeance: Ignore Pain)&buff(Ultimatum)}||{buff(Vengeance: Ignore Pain)&rage>=30}||{talent(6,1)&!buff(Ultimatum)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)&rage<30}'},
+	{'!Ignore Pain','{buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage>=13}||{!buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage>=20}||{rage>=60&!talent(6,1)}||{buff(Vengeance: Ignore Pain)&buff(Ultimatum)}||{buff(Vengeance: Ignore Pain)&rage>=30}||{talent(6,1)&!buff(Ultimatum)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)&rage<30}'},
 	--actions.prot+=/focused_rage,if=(buff.vengeance_focused_rage.up&!buff.vengeance_ignore_pain.up)||(buff.ultimatum.up&buff.vengeance_focused_rage.up&!buff.vengeance_ignore_pain.up)||(talent.vengeance.enabled&buff.ultimatum.up&!buff.vengeance_ignore_pain.up&!buff.vengeance_focused_rage.up)||(talent.vengeance.enabled&!buff.vengeance_ignore_pain.up&!buff.vengeance_focused_rage.up&rage>=30)||(buff.ultimatum.up&buff.vengeance_ignore_pain.up&cooldown.shield_slam.remains=0&rage<10)||(rage>=100)
 	{'Focused Rage', '{buff(Vengeance: Focused Rage)&!buff(Vengeance: Ignore Pain)}||{buff(Ultimatum)&buff(Vengeance: Focused Rage)&!buff(Vengeance: Ignore Pain)}||{talent(6,1)&buff(Ultimatum)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)}||{talent(6,1)&!buff(Vengeance: Ignore Pain)&!buff(Vengeance: Focused Rage)&rage>=30}||{buff(Ultimatum)&buff(Vengeance: Ignore Pain)&spell(Shield Slam)&rage<10}||{rage>=100}'},
 	--actions.prot+=/demoralizing_shout,if=incoming_damage_2500ms>health.max*0.20
@@ -127,7 +127,8 @@ local ST = {
 	--actions.prot+=/neltharions_fury,if=incoming_damage_2500ms>health.max*0.20&!buff.shield_block.up
 	{'Neltharion\'s Fury', 'incdmg(2.5)>health.max*0.20&!buff(Shield Block)'},
 	--actions.prot+=/shield_slam,if=!(cooldown.shield_block.remains<=gcd.max*2&!buff.shield_block.up&talent.heavy_repercussions.enabled)
-	{'Shield Slam', '!{spell(Shield Block).cooldown<=gcd*2&!buff(Shield Block)&talent(7,2)}||{rage<=5}'},
+	{'Shield Slam', '!{spell(Shield Block).cooldown<=gcd&!buff(Shield Block)&talent(7,2)}||{buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage<13}||{!buff(Vengeance: Ignore Pain)&buff(Ignore Pain).duration<=gcd*2&rage<20}||'},
+	{'Shield Slam', '!talent(7,2)'},
 	--actions.prot+=/revenge,if=cooldown.shield_slam.remains<=gcd.max*2
 	{'Revenge', '{spell(Shield Slam).cooldown<=gcd*2||rage<=5}'},
 	--actions.prot+=/devastate


### PR DESCRIPTION
- Interrupts seem to be working fine raiding & in mythic+, i'll keep testing though
- Last stand should be the last panic CD before death; if something is going to kill you for sure use it but otherwise save it (not sure about the syntax for comparing inc damage to current health).
- Neltharion's Fury is an AOE cone so we should be facing the enemies before using it.
- Demoralizing Shout should be used on aoe-packs to reduce incoming damage early on in the fight while building Ignore Pain.
- Revenge should be used right before the Shield Slam cooldown unless rage-capped to generate rage faster. 
- Focused rage commented as suggested erlier; this increased suitability quite a bit against Emerald Nightmare HC bosses.
